### PR TITLE
fix: peer dependency version syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "all": true
   },
   "peerDependencies": {
-    "semantic-release": ">=19.0.0 <20.0.0"
+    "semantic-release": "^19.0.0"
   },
   "prettier": {
     "printWidth": 120,


### PR DESCRIPTION
Fixes the following warning I got:

```
warning " > @getoutreach/semantic-release-circleci-orb@1.1.9" has incorrect peer dependency "semantic-release@>=19.0.0 <20.0.0"
```